### PR TITLE
fix(hook): retry on 4xx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Retry on 4xx errors
 
 # v0.1.2 
 - Documentation and wording fixes
@@ -9,4 +10,3 @@
 - Add link to the application overview in the task
 - CI workflow
 - Initial documentation
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+# v0.1.3
 - Retry on 4xx errors
+- Fix mypy errors
+- Fix documentation code sample
 
 # v0.1.2 
 - Documentation and wording fixes

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-PROJECT_VERSION=0.1.2
+PROJECT_VERSION=0.1.3
 SRCS=$(shell git ls-files -c)
 DEPS=$(SRCS) pyproject.toml
 PROJECT_NAME=ocean-spark-airflow-provider

--- a/ocean_spark/__init__.py
+++ b/ocean_spark/__init__.py
@@ -7,6 +7,7 @@ import ocean_spark.extra_links
 def get_provider_info() -> Dict:
     return {
         "versions": [
+            "0.1.3",
             "0.1.2",
             "0.1.1",
             "0.1.0",

--- a/ocean_spark/hooks.py
+++ b/ocean_spark/hooks.py
@@ -183,6 +183,8 @@ class OceanSparkHook(BaseHook):
 
 
 def _retryable_error(exception: requests_exceptions.RequestException) -> bool:
+    # Since the Spot API masks all internal errors as 400s, the hook must retry
+    # even on 4xx errors.
     return isinstance(
         exception, (requests_exceptions.ConnectionError, requests_exceptions.Timeout)
-    ) or (exception.response is not None and exception.response.status_code >= 500)
+    ) or (exception.response is not None and exception.response.status_code >= 400)


### PR DESCRIPTION
Since the Spot API masks internal errors, including transient errors,
as 400s, the hook must retry on 4xx errors.